### PR TITLE
Add pipx ansible-lint install instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Alternative installation methods (like [Poetry](https://python-poetry.org/), [Ho
 
 `ansible-lint` needs to be runnable directly from your computer's command line.
 
-If your package manager doesn't provide `ansible-lint` or you want to install a more up-to-date version, then a suggested setup would be as follows:
+If your package manager doesn't provide `ansible-lint` or you want to install a more up-to-date version, then a suggested setup would be as follows: 
 
+_NOTE_ 
+
+This will result in ansbile-lint using the latest version of ansible supported by ansible-lint. If you need a specific version of ansible see [Pipx](#pipx) instructions below
 * create an `ansible-lint` folder in your home directory:
   ```
   mkdir ~/ansible-lint
@@ -80,6 +83,29 @@ If your package manager doesn't provide `ansible-lint` or you want to install a 
   ```
 
 Reference this script in the plugin; and you should be ready to go. 👍
+
+## Pipx
+
+Pipx can be used as an alternative to manually configuring a venv. It has the advantage of automatically adding the installed binaries to your path and allows specifying the ansible verion ansible-lint uses
+
+* Remove apt installed ansible
+  ```
+  sudo apt remove ansible*
+  ```
+
+* Install [Pipx](https://pipx.pypa.io/stable/installation/)
+  
+* Install ansible with pipx (change 6.7.0 to your required version, or remove it to install the latest)
+  ```
+  pipx install --include-deps ansible==6.7.0
+  ```
+
+* Inject ansible-lint into the pipx ansible venv 
+  ```
+  pipx inject --include-deps ansible ansible-lint
+  ```
+
+`ansible` and `ansible-lint` should now be availible in your path
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Alternative installation methods (like [Poetry](https://python-poetry.org/), [Ho
 
 `ansible-lint` needs to be runnable directly from your computer's command line.
 
-If your package manager doesn't provide `ansible-lint` or you want to install a more up-to-date version, then a suggested setup would be as follows: 
+If your package manager doesn't provide `ansible-lint` or you want to install a more up-to-date version, then a suggested setup would be as follows:
 
 _NOTE_ 
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Pipx can be used as an alternative to manually configuring a venv. It has the ad
   sudo apt remove ansible*
   ```
 
-* Install [Pipx](https://pipx.pypa.io/stable/installation/)
+* Install [Pipx](https://pipx.pypa.io/stable/)
   
 * Install ansible with pipx (change 6.7.0 to your required version, or remove it to install the latest)
   ```


### PR DESCRIPTION
Hello, I walked through your installation instructions and found the ansible-lint install instructions incompatible with some work projects. We pin our ansible version and I ended up using pipx to manage ansible and ansible-lint. I think this is better than a raw venv as it automatically adds installed binaries to your path and removes the requirement for creating and referencing a script in the plugin. 

No worries if you don't want to include my changes but I figured I'd document my process in case anyone else needed this to work with a pinned version of ansible.